### PR TITLE
Fix Discord link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 - **More Sounds** - More sound effects and instrument sounds for the piano tab
 - **UI themes/improvements**
 
-> If you want to stay updated on new versions/updates or have some suggestions/feedback, consider joining the [Discord](discord.gg/XSXU7AaQjx )!
+> If you want to stay updated on new versions/updates or have some suggestions/feedback, consider joining the [Discord](https://discord.gg/XSXU7AaQjx)!
 
 ### Credits
 


### PR DESCRIPTION
without `https://` in the Markdown Link, it will redirect to `https://github.com/joshxviii/animalese-typing-desktop/blob/main/discord.gg/XSXU7AaQjx` instead of the Discord URL