### PR TITLE
perf: reduce idle polling and neutral intonation timers

### DIFF
--- a/main.js
+++ b/main.js
@@ -110,6 +110,7 @@ ipcMain.handle('store-set', async (e, key, value) => {
     }
     else if(key==='anchor_window') updateWindow();
     else if (key==='disable_hotkey') updateDisableHotkey(value);
+    handlePreferenceSideEffects(key);
 });
 const nonResettable = [
     'lang',
@@ -122,6 +123,7 @@ ipcMain.handle('store-reset', async (e, key) => {// reset a certain key or all s
         preferences.set(key, defaults[key]);
         bgwin.webContents.send(`updated-${key}`, defaults[key]);
         if (key==='disable_hotkey') updateDisableHotkey(defaults[key]);
+        handlePreferenceSideEffects(key);
     }
     else {// reset all
         Object.keys(preferences.store).forEach(key => { if (!nonResettable.includes(key)) preferences.delete(key); });
@@ -133,6 +135,7 @@ ipcMain.handle('store-reset', async (e, key) => {// reset a certain key or all s
                 if (key==='disable_hotkey') updateDisableHotkey(defaults[key]);
             }
         });
+        updateWindowMonitoring({ force: true });
     }
 });
 ipcMain.on('toggle-visibility', (e) => {
@@ -167,21 +170,75 @@ let muted = false;
 var disabled = muted || !preferences.get('always_active');
 let lastFocusedWindow = null;
 let focusedWindows = [];
+let windowMonitoringTimer = null;
+let focusedWindowCheckInFlight = false;
+
+function shouldMonitorFocusedWindow() {
+    // Selected-app mode must keep polling even while disabled by focus so it can detect return.
+    return Boolean(getFocusedWindow) && !muted && !preferences.get('always_active');
+}
+
+function stopWindowMonitoring({ resetFocus = false } = {}) {
+    if (windowMonitoringTimer) {
+        clearInterval(windowMonitoringTimer);
+        windowMonitoringTimer = null;
+    }
+    if (resetFocus) lastFocusedWindow = null;
+}
+
+function startWindowMonitoring({ force = false } = {}) {
+    if (!shouldMonitorFocusedWindow()) {
+        stopWindowMonitoring({ resetFocus: force });
+        return;
+    }
+
+    if (!windowMonitoringTimer) windowMonitoringTimer = setInterval(monitorFocusedWindow, 500);
+
+    if (force) {
+        lastFocusedWindow = null;
+        monitorFocusedWindow();
+    }
+}
+
+function updateWindowMonitoring({ force = false } = {}) {
+    if (muted) {
+        stopWindowMonitoring({ resetFocus: true });
+        setDisable(true);
+        return;
+    }
+
+    if (preferences.get('always_active')) {
+        stopWindowMonitoring({ resetFocus: true });
+        setDisable(false);
+        return;
+    }
+
+    setDisable(true);
+    // Stay conservative until the async focus check proves the current app is allowed.
+    startWindowMonitoring({ force });
+}
+
+function handlePreferenceSideEffects(key) {
+    if (['always_active', 'selected_apps', 'selected_active'].includes(key)) {
+        updateWindowMonitoring({ force: true });
+    }
+}
 
 // check for active window changes and update `lastFocusedWindow` when the window changes
 async function monitorFocusedWindow() {
-    // Skip window monitoring on Linux or if getFocusedWindow is not available
-    if (!getFocusedWindow) return;
+    if (!shouldMonitorFocusedWindow() || focusedWindowCheckInFlight) return;
     
+    focusedWindowCheckInFlight = true;
     try {
         const focusedWindow = await getFocusedWindow();
+        if (!shouldMonitorFocusedWindow()) return;
 
         if (!focusedWindow?.owner?.name) return;// return early if invalid window
 
         const winName = focusedWindow.owner.name
         if (winName === lastFocusedWindow?.owner?.name) return;// return early if the active window hasn't changed.
         
-        const selectedApps = preferences.get('selected_apps');
+        const selectedApps = preferences.get('selected_apps') || [];
 
         // change disable value when focusing in or out of selected-apps.
         setDisable( (preferences.get('selected_active')?!selectedApps.includes(winName):selectedApps.includes(winName)) && 
@@ -191,15 +248,13 @@ async function monitorFocusedWindow() {
         if (!focusedWindows.includes(winName)) {
             focusedWindows.push(winName);
             if (focusedWindows.length > 8) focusedWindows.shift();
-            bgwin.webContents.send('focused-window-changed', focusedWindows);
+            bgwin?.webContents?.send('focused-window-changed', focusedWindows);
         }
     } catch (error) {
         console.debug('Window monitoring error:', error.message);
+    } finally {
+        focusedWindowCheckInFlight = false;
     }
-}
-
-function startWindowMonitoring() {
-    setInterval(monitorFocusedWindow, 500); // check window every .5 seconds
 }
 
 function updateWindow() {
@@ -324,9 +379,7 @@ function updateTrayMenu() {
             accelerator: preferences.get('disable_hotkey'),
             checked: muted,
             click: (menuItem) => { 
-                muted = menuItem.checked;
-                setDisable();
-                if (bgwin) bgwin.webContents.send('muted-changed', muted);
+                setMuted(menuItem.checked);
             }
         },
         {
@@ -378,8 +431,12 @@ function updateDisableHotkey(hotkey) {
 }
 
 function toggleMuted() {
-    muted = !muted;
-    setDisable(muted);
+    setMuted(!muted);
+}
+
+function setMuted(value) {
+    muted = value;
+    updateWindowMonitoring({ force: true });
     updateTrayMenu();
     if (bgwin) bgwin.webContents.send('muted-changed', muted);
 }
@@ -400,6 +457,8 @@ function setRunOnStartup(value) {
 let keyListener;
 
 async function startKeyListener() {
+    if (keyListener) return;
+
     const platform = process.platform;
     let listenerPath;
 
@@ -426,8 +485,9 @@ async function startKeyListener() {
     }
 
     //if (!keyListener) return;
-    keyListener = spawn(listenerPath);
-    keyListener.stdout.on('data', data => {
+    const listener = spawn(listenerPath);
+    keyListener = listener;
+    listener.stdout.on('data', data => {
         const lines = data.toString().split('\n').filter(Boolean);
 
         for (const line of lines) {
@@ -450,7 +510,7 @@ async function startKeyListener() {
             }
         }
     });
-    keyListener.stderr.on('data', data => {
+    listener.stderr.on('data', data => {
         const message = data.toString();
         console.log(`${platform}-listener:`, message);
         
@@ -467,7 +527,7 @@ async function startKeyListener() {
             });
         }
     });
-    keyListener.on('error', (err) => {
+    listener.on('error', (err) => {
         const errorMsg = err && err.message ? err.message : String(err);
         console.error('animalese-listener spawn error:', errorMsg);
         dialog.showMessageBox({
@@ -480,8 +540,9 @@ async function startKeyListener() {
             app.quit();
         });
     });
-    keyListener.on('exit', (code, signal) => {
+    listener.on('exit', (code, signal) => {
         console.error('animalese-listener exited:', code, signal);
+        if (keyListener === listener) keyListener = null;
         // only show alert if exited with error (non-zero code) and not killed by signal
         // if (code !== 0 && code !== null && !signal) {
         //     dialog.showMessageBox({
@@ -506,9 +567,9 @@ function stopKeyListener() {
 }
 
 app.on('ready', () => {
-    startWindowMonitoring();
     setupMainWin();
     createTrayIcon();
+    updateWindowMonitoring({ force: true });
     if (!disabled) startKeyListener();
     if (process.platform === 'darwin') app.dock.hide();
     bgwin.hide();
@@ -519,6 +580,7 @@ app.on('ready', () => {
     });
     powerMonitor.on('resume', () => {
         if (!disabled) startKeyListener();
+        updateWindowMonitoring({ force: true });
     });
 
     updateDisableHotkey(preferences.get('disable_hotkey'));
@@ -534,6 +596,7 @@ app.on('window-all-closed', function () {
 });
 
 app.on('before-quit', () => {
+    stopWindowMonitoring({ resetFocus: true });
     stopKeyListener();
     if (keyListener) {
         keyListener.kill('SIGKILL');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "animalese-typing",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "animalese-typing",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "child_process": "^1.0.2",

--- a/utils/audio-manager.cjs
+++ b/utils/audio-manager.cjs
@@ -22,6 +22,7 @@ const file_type = ".ogg";
 
 const waitingForRelease = {};// a list of audio paths waiting for key up event to be released
 const activeChannels = {};// map of currently playing sounds on a given channel (only one sound per channel)
+const INTONATION_EPSILON = 1e-6;
 
 //#region Audio Sprite Maps
 // (60,000/2) / 150bpm = 200ms
@@ -153,7 +154,10 @@ function releaseSound(release_id, cut = true) {
 }
 
 function applyIntonation(bank, id, intonation, currentRate = 1, ramp = 2) {
-const duration = 3200; // ms duration for ramp
+    // Neutral intonation is an audible no-op, so avoid scheduling a 64-step timer ramp.
+    if (!Number.isFinite(intonation) || Math.abs(intonation) <= INTONATION_EPSILON) return [];
+
+    const duration = 3200; // ms duration for ramp
     const startRate = Math.max(currentRate, 0.01);
     const endRate = startRate * (
         intonation >= 0
@@ -162,6 +166,7 @@ const duration = 3200; // ms duration for ramp
     );
     const steps = 64;
     const interval = duration / steps;
+    const timers = [];
 
     for (let i = 1; i <= steps; i++) {
         const t = i / steps;
@@ -173,14 +178,25 @@ const duration = 3200; // ms duration for ramp
     
         const rate = startRate * ((endRate / startRate) ** easedT);
 
-        setTimeout(() => bank.rate(rate, id), i * interval);
+        timers.push(setTimeout(() => {
+            if (bank.playing(id)) bank.rate(rate, id);
+        }, i * interval));
     }
+
+    return timers;
+}
+
+function clearAudioTimers(audio) {
+    if (!audio?.intonationTimers) return;
+    for (const timer of audio.intonationTimers) clearTimeout(timer);
+    audio.intonationTimers = [];
 }
 
 // audio channel cutoff logic
 function cutOffAudio(audio, release=0.025) {
-    CUTOFF_DURATION=release;
+    const CUTOFF_DURATION=release;
     const prev = audio;
+    clearAudioTimers(prev);
     if (!prev || !prev.bank.playing(prev.id)) return;
 
     prev.bank.fade(prev.bank.volume(prev.id), 0, CUTOFF_DURATION * 1000, prev.id);
@@ -299,10 +315,11 @@ function createAudioManager() {
         bank.rate(rate, id);
         
         // apply intonation
-        if (intonation !== undefined) applyIntonation(bank, id, intonation, bank.rate(id));
+        const intonationTimers = intonation !== undefined ? applyIntonation(bank, id, intonation, bank.rate(id)) : [];
+        const audioHandle = { bank, id, intonationTimers };
         // add this sound to a cutoff channel
-        if (channel !== undefined) activeChannels[channel] = { bank, id };
-        if (hold !== undefined) waitingForRelease[hold] = { bank, id };
+        if (channel !== undefined) activeChannels[channel] = audioHandle;
+        if (hold !== undefined) waitingForRelease[hold] = audioHandle;
     }
     return { play: playSound, release: releaseSound };
 }


### PR DESCRIPTION
## Summary

Reduce unnecessary wakeups in the default app path by limiting active-window polling and avoiding neutral intonation timer ramps.

## Changes

- Gate active-window polling to selected-app mode only.
- Keep selected-app polling alive while focus disables the listener, so return-to-allowed-app still works.
- Recompute focused-window state on relevant settings changes, resets, mute/unmute, and resume.
- Skip zero/non-finite intonation ramps and clear pending intonation timers on cutoff.
- Sync `package-lock.json` version metadata with `package.json` so `npm ci` works in release CI.

## Compatibility

This PR is Mac-motivated but only touches shared JavaScript. It does not change native key listeners, listener stdout JSON, build scripts, packaging resources, or dependencies.

Linux/missing `getFocusedWindow` paths create no polling interval. Windows/macOS selected-app behavior is preserved when the helper is available.

## Testing

- `node --check main.js`
- `node --check utils/audio-manager.cjs`
- `git diff --check`
- `npm exec --yes --package npm@10 -- npm ci --cache /private/tmp/animalese-npm-cache`
- `npm run build:mac-listener`
- `npm start` on macOS
- macOS selected-app focus transition with Safari as the allowed app:
  - disallowed app focused at startup: Electron running, no `animalese-listener`
  - Safari focused: app logged `Starting animalese-listener` and listener process appeared
  - user confirmed Safari focus transition behavior worked

## Notes

- Local Node 25/npm 11 `npm ci` hit an npm CLI internal error after the lockfile mismatch was fixed, so install verification used npm 10 to better match the repo's Node 20 release workflow.
- Windows/Linux runtime testing was not performed locally.
